### PR TITLE
[Scan] Add initial Redshift support

### DIFF
--- a/scanamabob/commands/scan.py
+++ b/scanamabob/commands/scan.py
@@ -9,6 +9,7 @@ import scanamabob.scans.s3 as s3
 import scanamabob.scans.cloudtrail as cloudtrail
 import scanamabob.scans.elb as elb
 import scanamabob.scans.rds as rds
+import scanamabob.scans.redshift as redshift
 from scanamabob.context import Context, add_context_to_argparse
 
 
@@ -35,7 +36,8 @@ scan_suites = {
     's3': s3.scans,
     'cloudtrail': cloudtrail.scans,
     'elb': elb.scans,
-    'rds': rds.scans
+    'rds': rds.scans,
+    'redshift': redshift.scans
 }
 
 

--- a/scanamabob/context.py
+++ b/scanamabob/context.py
@@ -1,9 +1,11 @@
+import json
 import os
 import sys
+import urllib.request
+from ipaddress import ip_network
 from configparser import ConfigParser
 from scanamabob.services.ec2 import get_regions
 from boto3.session import Session
-
 
 def add_context_to_argparse(parser):
     parser.add_argument('-p', '--profiles', default='default',
@@ -43,6 +45,14 @@ class Context(object):
         # State is a flexible member that can be used to track within a command
         self.state = None
 
+        # Load AWS CIDRs
+        self.cidrs = set()
+        with urllib.request.urlopen('https://ip-ranges.amazonaws.com/ip-ranges.json') as url:
+            ip_ranges = json.loads(url.read().decode())
+            for prefix in ip_ranges['prefixes']:
+                if 'ip_prefix' in prefix:
+                    self.cidrs.add(prefix['ip_prefix'])
+
     def set_profile(self, profile):
         self.current_profile = profile
         self.session = Session(profile_name=profile)
@@ -54,3 +64,9 @@ class Context(object):
                 print(f'{region} was not found to be a valid region')
                 valid = False
         return valid
+
+    def is_aws_cidr(self, cidr):
+        for aws_cidr in self.cidrs:
+            if ip_network(cidr).subnet_of(ip_network(aws_cidr)):
+                return True
+        return False

--- a/scanamabob/scans/redshift.py
+++ b/scanamabob/scans/redshift.py
@@ -1,0 +1,64 @@
+from scanamabob.services.ec2 import get_region_secgroups
+from scanamabob.services.redshift import client
+from scanamabob.scans import Finding, Scan, ScanSuite
+
+
+class PubliclyAccessibleScan(Scan):
+    title = 'Verifying Redshift clusters are not publicly accessible'
+    permissions = ['']
+
+    def run(self, context):
+        findings = []
+        cluster_count = 0
+        public_count = 0
+        public = {}
+
+        # First find any cluster that is `PubliclyAccessibble`.
+        for region in context.regions:
+            redshift = client(context, region_name=region)
+            for page in redshift.get_paginator('describe_clusters').paginate():
+                for cluster in page['Clusters']:
+                    cluster_count += 1
+                    if cluster['PubliclyAccessible']:
+                        public_count += 1
+                        if region not in public:
+                            public[region] = []
+                        cluster_id = cluster['ClusterIdentifier']
+                        port = cluster['Endpoint']['Port']
+                        security_groups = {group['VpcSecurityGroupId']: [] for group in cluster['VpcSecurityGroups']}
+                        public[region].append({'id': cluster_id, 'port': port, 'security_groups': security_groups})
+
+        # Next see if there are security groups in place for the found clusters.
+        severity = 'LOW'
+        for region in public:
+            for cluster in public[region]:
+                for group in get_region_secgroups(context, region):
+                    group_id = group['GroupId']
+                    if group_id not in cluster['security_groups']:
+                        continue
+                    for permission in group['IpPermissions']:
+                        if permission['IpRanges'] == []:
+                            continue
+                        if permission['FromPort'] != cluster['port']:
+                            continue
+                        for ip in permission['IpRanges']:
+                            cidr_ip = ip['CidrIp']
+                            if cidr_ip == "0.0.0.0/0":
+                                severity = 'HIGH'
+                                cluster['security_groups'][group_id].append({'source': cidr_ip, 'class': 'Internet'})
+                            elif context.is_aws_cidr(cidr_ip):
+                                severity = 'MEDIUM'
+                                cluster['security_groups'][group_id].append({'source': cidr_ip, 'class': 'AWS'})
+
+        if public_count:
+            findings.append(Finding(context.state,
+                                    'Redshift clusters are publicly accessible',
+                                    severity,
+                                    cluster_count=cluster_count,
+                                    public_count=public_count,
+                                    instances=public))
+        return findings
+
+
+scans = ScanSuite('Redshift Scans',
+                  {'public': PubliclyAccessibleScan()})

--- a/scanamabob/services/redshift.py
+++ b/scanamabob/services/redshift.py
@@ -1,0 +1,4 @@
+def client(context, **kwargs):
+    ''' Return an Redshift client handle for the given context '''
+    return context.session.client('redshift', **kwargs)
+


### PR DESCRIPTION
This commit adds the initial infrastructure for working with Redshift
and one scan to look for public Redshift clusters. The analysis is
smart enough to adjust the severity according to whether the cluster
is public with:

1. No security groups allowing access (LOW).
2. Security groups allowing acceess from an AWS CIDR (MEDIUM).
3. Security groups allowing access from the Public Internet (HIGH).

Examples:

* LOW * Redshift clusters are publicly accessible (redshift.public)
{
    "cluster_count": 1,
    "public_count": 1,
    "instances": {
        "us-east-1": [
            {
                "id": "redshift-cluster-1",
                "port": 5439,
                "security_groups": {
                    "sg-08e5091c908596e51": []
                }
            }
        ]
    }
}

* MEDIUM * Redshift clusters are publicly accessible (redshift.public)
{
    "cluster_count": 1,
    "public_count": 1,
    "instances": {
        "us-east-1": [
            {
                "id": "redshift-cluster-1",
                "port": 5439,
                "security_groups": {
                    "sg-08e5091c908596e51": [],
                    "sg-09fd0a371c3e13085": [
                        {
                            "source": "54.86.164.236/32",
                            "class": "AWS"
                        }
                    ]
                }
            }
        ]
    }
}

* HIGH * Redshift clusters are publicly accessible (redshift.public)
{
    "cluster_count": 1,
    "public_count": 1,
    "instances": {
        "us-east-1": [
            {
                "id": "redshift-cluster-1",
                "port": 5439,
                "security_groups": {
                    "sg-09fd0a371c3e13085": [
                        {
                            "source": "0.0.0.0/0",
                            "class": "Internet"
                        }
                    ]
                }
            }
        ]
    }
}