### PR TITLE
[Scan] Look for Reshift clusters with SSL disabled

### DIFF
--- a/scanamabob/scans/redshift.py
+++ b/scanamabob/scans/redshift.py
@@ -60,5 +60,55 @@ class PubliclyAccessibleScan(Scan):
         return findings
 
 
+class SSLEnabledScan(Scan):
+    title = 'Verifying Redshift clusters are using SSL'
+    permissions = ['']
+
+    def run(self, context):
+        findings = []
+        parameter_group_count = 0
+        no_ssl_count = 0
+        groups_without_ssl = {}
+        instances = {}
+
+        # Search for parameter groups wit SSL disabled.
+        for region in context.regions:
+            redshift = client(context, region_name=region)
+            for page in redshift.get_paginator('describe_cluster_parameter_groups').paginate():
+                for parameter_group in page['ParameterGroups']:
+                    parameter_group_count += 1
+                    group_name = parameter_group['ParameterGroupName']
+                    for parameter in redshift.describe_cluster_parameters(ParameterGroupName=group_name)['Parameters']:
+                        if parameter['ParameterName'] == 'require_ssl' and parameter['ParameterValue'] == 'false':
+                            no_ssl_count += 1
+                            if region not in groups_without_ssl:
+                                groups_without_ssl[region] = []
+                            groups_without_ssl[region].append({'group_name': group_name, 'in_use': False})
+
+        # Next see if those parameter groups are actually used.
+        severity = 'INFO'
+        instances = {}
+        for region in context.regions:
+            redshift = client(context, region_name=region)
+            for page in redshift.get_paginator('describe_clusters').paginate():
+                for cluster in page['Clusters']:
+                    for parameter_group in cluster['ClusterParameterGroups']:
+                        group_name = parameter_group['ParameterGroupName']
+                        for other_group in groups_without_ssl[region]:
+                            if other_group['group_name'] == group_name:
+                                other_group['in_use'] = True
+                                severity = 'MEDIUM'
+
+        if no_ssl_count:
+            findings.append(Finding(context.state,
+                                    'Redshift cluster parameter groups with SSL disabled',
+                                    severity,
+                                    parameter_group_count=parameter_group_count,
+                                    no_ssl_count=no_ssl_count,
+                                    instances=groups_without_ssl))
+        return findings
+
+
 scans = ScanSuite('Redshift Scans',
-                  {'public': PubliclyAccessibleScan()})
+                  {'public': PubliclyAccessibleScan(),
+                   'ssl': SSLEnabledScan()})


### PR DESCRIPTION
This commit adds support for identifying Redshift clusters
that do *not* have SSL enabled. The analysis is smart enough
to adjust the severity depending on whether the parameter
group in question is used or not.

Examples:

* INFO * Redshift cluster parameter groups with SSL disabled (redshift.ssl)
{
    "parameter_group_count": 2,
    "no_ssl_count": 1,
    "instances": {
        "us-east-1": [
            {
                "group_name": "default.redshift-1.0",
                "in_use": false
            }
        ]
    }
}

* MEDIUM * Redshift cluster parameter groups with SSL disabled (redshift.ssl)
{
    "parameter_group_count": 2,
    "no_ssl_count": 2,
    "instances": {
        "us-east-1": [
            {
                "group_name": "bad-group",
                "in_use": true
            },
            {
                "group_name": "default.redshift-1.0",
                "in_use": false
            }
        ]
    }
}