### PR TITLE
Redshift parameter group scan

### DIFF
--- a/scanamabob/scans/redshift.py
+++ b/scanamabob/scans/redshift.py
@@ -60,5 +60,55 @@ class PubliclyAccessibleScan(Scan):
         return findings
 
 
+class SSLEnabledScan(Scan):
+    title = 'Verifying Redshift clusters are using SSL'
+    permissions = ['']
+
+    def run(self, context):
+        findings = []
+        parameter_group_count = 0
+        no_ssl_count = 0
+        groups_without_ssl = {}
+        instances = {}
+
+        # Search for parameter groups wit SSL disabled.
+        for region in context.regions:
+            redshift = client(context, region_name=region)
+            for page in redshift.get_paginator('describe_cluster_parameter_groups').paginate():
+                for parameter_group in page['ParameterGroups']:
+                    parameter_group_count += 1
+                    group_name = parameter_group['ParameterGroupName']
+                    for parameter in redshift.describe_cluster_parameters(ParameterGroupName=group_name)['Parameters']:
+                        if parameter['ParameterName'] == 'require_ssl' and parameter['ParameterValue'] == 'false':
+                            no_ssl_count += 1
+                            if region not in groups_without_ssl:
+                                groups_without_ssl[region] = []
+                            groups_without_ssl[region].append({'group_name': group_name, 'in_use': False})
+
+        # Next see if those parameter groups are actually used.
+        severity = 'INFO'
+        instances = {}
+        for region in context.regions:
+            redshift = client(context, region_name=region)
+            for page in redshift.get_paginator('describe_clusters').paginate():
+                for cluster in page['Clusters']:
+                    for parameter_group in cluster['ClusterParameterGroups']:
+                        group_name = parameter_group['ParameterGroupName']
+                        for other_group in groups_without_ssl[region]:
+                            if other_group['group_name'] == group_name:
+                                other_group['in_use'] = True
+                                severity = 'MEDIUM'
+
+        if no_ssl_count:
+            findings.append(Finding(context.state,
+                                    'Redshift cluster parameter groups with SSL disabled',
+                                    severity,
+                                    parameter_group_count=parameter_group_count,
+                                    no_ssl_count=no_ssl_count,
+                                    instances=groups_without_ssl))
+        return findings
+
+
 scans = ScanSuite('Redshift Scans',
-                  {'public': PubliclyAccessibleScan()})
+                  {'public': PubliclyAccessibleScan(),
+                   'ssl': SSLEnabledScan()})


### PR DESCRIPTION
This series adds some scans that look through Redshift parameter groups for bad things.  It is smart enough to ignore the default group when it isn't being used (since the default group can't be edited).