### PR TITLE
[Scan] Look for RDS instances with a single AZ

### DIFF
--- a/scanamabob/scans/rds.py
+++ b/scanamabob/scans/rds.py
@@ -2,36 +2,62 @@ from scanamabob.services.rds import client
 from scanamabob.scans import Finding, Scan, ScanSuite
 
 
-class EncryptionScan(Scan):
-    title = 'Verifying RDS instances have encryption enabled'
+class PropertyScan(Scan):
+    title = ''
     permissions = ['']
+
+    def __init__(self, name, value, title):
+        self.name = name
+        self.value = value
+        self.title = title
 
     def run(self, context):
         findings = []
         rds_count = 0
-        unenc_count = 0
-        unenc = {}
+        flagged_rds_count = 0
+        flagged = {}
 
         for region in context.regions:
             rds = client(context, region_name=region)
             for page in rds.get_paginator('describe_db_instances').paginate():
                 for db in page['DBInstances']:
                     rds_count += 1
-                    if not db['StorageEncrypted']:
-                        unenc_count += 1
-                        if region not in unenc:
-                            unenc[region] = []
-                        unenc[region].append(db['DBInstanceIdentifier'])
+                    if db[self.name] == self.value:
+                        flagged_rds_count += 1
+                        if region not in flagged:
+                            flagged[region] = []
+                        flagged[region].append(db['DBInstanceIdentifier'])
 
-        if unenc_count:
+        if flagged_rds_count:
             findings.append(Finding(context.state,
-                                    'RDS instances without encryption',
+                                    self.title,
                                     'LOW',
                                     rds_count=rds_count,
-                                    unenc_count=unenc_count,
-                                    instances=unenc))
+                                    flagged_rds_count=flagged_rds_count,
+                                    instances=flagged))
         return findings
 
 
+class EncryptionScan(PropertyScan):
+    title = 'Verifying RDS instances have encryption enabled'
+    permissions = ['']
+
+    def __init__(self):
+        super().__init__('StorageEncrypted',
+                         False,
+                         'RDS instances without encryption')
+
+
+class MultiAZScan(PropertyScan):
+    title = 'Verifying RDS instances are in multiple availability zones'
+    permissions = ['']
+
+    def __init__(self):
+        super().__init__('MultiAZ',
+                         False,
+                         'RDS instances without multiple availability zones')
+
+
 scans = ScanSuite('RDS Scans',
-                  {'encryption': EncryptionScan()})
+                  {'encryption': EncryptionScan(),
+                   'multiaz': MultiAZScan()})


### PR DESCRIPTION
This commit adds support for finding RDS instances with
a single AZ. This could lead to denial of service in the
system.

Some refactoring was done to accomplish this. The `multiaz`
scan is essentially the same as the existing `encryption`
scan since they both just look for property name/value
states. A generic `PropertyScan` class was created that
can be inherited to match particular property states.

Example:

 * LOW * RDS instances without multiple availability zones (rds.multiaz)
{
    "rds_count": 1,
    "flagged_rds_count": 1,
    "instances": {
        "us-east-1": [
            "airflow"
        ]
    }
}