### PR TITLE
[Scan] Add initial EKS support

### DIFF
--- a/scanamabob/commands/scan.py
+++ b/scanamabob/commands/scan.py
@@ -5,6 +5,7 @@ import json
 from argparse import ArgumentParser
 import scanamabob.scans.iam as iam
 import scanamabob.scans.ec2 as ec2
+import scanamabob.scans.eks as eks
 import scanamabob.scans.s3 as s3
 import scanamabob.scans.cloudtrail as cloudtrail
 import scanamabob.scans.elb as elb
@@ -32,6 +33,7 @@ parser.add_argument('scantypes', nargs='*',
 scan_suites = {
     'iam': iam.scans,
     'ec2': ec2.scans,
+    'eks': eks.scans,
     's3': s3.scans,
     'cloudtrail': cloudtrail.scans,
     'elb': elb.scans,

--- a/scanamabob/scans/eks.py
+++ b/scanamabob/scans/eks.py
@@ -1,0 +1,37 @@
+from scanamabob.services.eks import client, list_clusters
+from scanamabob.scans import Finding, Scan, ScanSuite
+
+
+class PubliclyAccessibleAPIServerScan(Scan):
+    title = 'Verifying EKS API servers are not publicly accessible'
+    permissions = ['']
+
+    def run(self, context):
+        findings = []
+        cluster_count = 0
+        public_count = 0
+        public = {}
+
+        for region in context.regions:
+            eks = client(context, region_name=region)
+            for cluster_name in list_clusters(context, region):
+                cluster_count += 1
+                cluster = eks.describe_cluster(name=cluster_name)['cluster']
+                if cluster['resourcesVpcConfig']['endpointPublicAccess']:
+                    public_count += 1
+                    if region not in public:
+                        public[region] = []
+                    public[region].append({'name': cluster_name, 'endpoint': cluster['endpoint']})
+
+        if public_count:
+            findings.append(Finding(context.state,
+                                    'EKS API server endpoints are publicly accessible',
+                                    'MEDIUM',
+                                    cluster_count=cluster_count,
+                                    public_count=public_count,
+                                    instances=public))
+        return findings
+
+
+scans = ScanSuite('EKS Scans',
+                  {'public': PubliclyAccessibleAPIServerScan()})

--- a/scanamabob/services/eks.py
+++ b/scanamabob/services/eks.py
@@ -1,0 +1,19 @@
+import botocore
+
+
+def client(context, **kwargs):
+    ''' Return an EKS client handle for the given context '''
+    return context.session.client('eks', **kwargs)
+
+
+def list_clusters(context, region):
+    eks = client(context, region_name=region)
+
+    # EKS is not available in all regions and `boto` throws a `ClientError`
+    # exception when the service is *not* available.
+    try:
+        for page in eks.get_paginator('list_clusters').paginate():
+            for cluster_name in page['clusters']:
+                yield cluster_name
+    except botocore.exceptions.ClientError as err:
+        pass


### PR DESCRIPTION
This commit adds the initial infrastructure for working with EKS
and one scan to look for public EKS API server endpoints.

Example:

* MEDIUM * EKS API server endpoints are publicly accessible (eks.public)
{
    "cluster_count": 1,
    "public_count": 1,
    "instances": {
        "us-east-1": [
            {
                "name": "Test",
                "endpoint": "https://17C63FD4D42C3C4B1334718C2B93C617.gr7.us-east-1.eks.amazonaws.com"
            }
        ]
    }
}