### PR TITLE
Add RDS backups test

### DIFF
--- a/scanamabob/scans/rds.py
+++ b/scanamabob/scans/rds.py
@@ -48,6 +48,14 @@ class EncryptionScan(PropertyScan):
                          'RDS instances without encryption')
 
 
+class BackupsScan(PropertyScan):
+    title = 'Verifying RDS instances have backups enabled'
+    permissions = ['']
+
+    def __init__(self):
+        super().__init__('BackupRetentionPeriod', 0, 'RDS instances without backups')
+
+
 class MultiAZScan(PropertyScan):
     title = 'Verifying RDS instances are in multiple availability zones'
     permissions = ['']
@@ -60,4 +68,5 @@ class MultiAZScan(PropertyScan):
 
 scans = ScanSuite('RDS Scans',
                   {'encryption': EncryptionScan(),
+                   'backups': BackupsScan(),
                    'multiaz': MultiAZScan()})


### PR DESCRIPTION
I also wrote an extension to `PropertyScan` to specify a function as an alternative to the value (when I thought testing for backups was going to be more complicated), but I removed it since it wasn't needed. lmk if you think other tests might need that and I can push it