### PR TITLE
[RDS] Make the MultiAZ scan cluster aware

### DIFF
--- a/scanamabob/services/rds.py
+++ b/scanamabob/services/rds.py
@@ -2,3 +2,14 @@ def client(context, **kwargs):
     ''' Return an RDS client handle for the given context '''
     return context.session.client('rds', **kwargs)
 
+
+def describe_db_instances(context, region):
+    rds = client(context, region_name=region)
+
+    for page in rds.get_paginator('describe_db_instances').paginate():
+        for db in page['DBInstances']:
+            yield db
+
+def describe_db_cluster(context, region, cluster_id):
+    rds = client(context, region_name=region)
+    return rds.describe_db_clusters(DBClusterIdentifier=cluster_id)['DBClusters'][0]


### PR DESCRIPTION
This patch fixes issue #37.  If a DB instance lives in a cluster, then
any properties defined on the cluster instance take precedence. For
example, the cluster `MultiAZ` property would take precedence over
the DB instance one.

This was causing false positive to be reported for DB instances in
any `MultiAZ` Aurora cluster.