### PR TITLE
Issue8 NotAction scan

### DIFF
--- a/scanamabob/scans/iam.py
+++ b/scanamabob/scans/iam.py
@@ -1,10 +1,8 @@
 from datetime import datetime, timezone
 from scanamabob.scans import Finding, Scan, ScanSuite
 from scanamabob.services.iam import client, resources, get_all_users, \
-    get_credential_report
+    get_credential_report, get_attached_iam_policy_documents
 from datetime import datetime
-
-
 
 class MfaScan(Scan):
     title = 'AWS IAM Users without Multi-Factor Authentication'
@@ -102,6 +100,46 @@ class RootAccessKey(Scan):
                     return [Finding(context.state, self.title, 'HIGH')]
         return []
 
+class NotActionScan(Scan):
+    title = 'NotAction directives present'
+    # DOUBLE CHECK
+    permissions = ['iam:GenerateCredentialReport', 'iam:GetCredentialReport']
+
+    def run(self, context):
+        iam = client(context)
+        poldocs = get_attached_iam_policy_documents(context)
+        not_action_policies = {}
+        try:
+            for arn in poldocs.keys():
+                not_action_resources = []
+                
+                poldoc = poldocs[arn][1]['PolicyVersion']['Document']['Statement']
+        
+                if type(poldoc) == list:
+                    # multiple statements in the policy document
+                    for stmt in poldoc:
+                        try:
+                            if stmt['Effect'] == 'Allow' and stmt['NotAction'] is not None:
+                                not_action_resources.append(stmt['Resource'])
+                        except KeyError:
+                            pass
+
+                elif type(poldoc) == dict:
+                    # single statement in the policy document
+                    if 'NotAction' in poldoc.keys() and poldoc['Effect'] == 'Allow':
+                        not_action_resources.append(poldoc['Resource'])
+
+                if len(not_action_resources) > 0:
+                    not_action_policies[arn] = not_action_resources
+            
+            if len(not_action_policies) > 0:
+                return [Finding(context.state, self.title, 'HIGH', 
+                    not_action_policies=not_action_policies)]
+            else:
+                return []
+        except Exception as err:
+            print(f'Unexpected error: {err}')
+            
 
 class PasswordPolicy(Scan):
     title = 'AWS account password policies'
@@ -184,4 +222,5 @@ scans = ScanSuite('IAM Scans',
                    'password_policy': PasswordPolicy(),
                    'key_rotation': KeyRotation(),
                    'root_mfa': RootMfaScan(),
-                   'password_age': PasswordAgeScan()})
+                   'password_age': PasswordAgeScan(),
+                   'not_action': NotActionScan()})

--- a/scanamabob/services/iam.py
+++ b/scanamabob/services/iam.py
@@ -1,8 +1,10 @@
 import boto3
 import time
+import IPython
 
 __cache_all_users = {}
 __cache_credential_report = {}
+__cache_attached_iam_policy_documents = {}
 
 
 def client(context, **kwargs):
@@ -41,7 +43,6 @@ def get_credential_report(context):
         return __cache_credential_report[context.current_profile]
 
     iam = client(context)
-
     # Use existing report if one already exists
     try:
         creds_csv = iam.get_credential_report()['Content'].decode('UTF-8')
@@ -67,3 +68,30 @@ def get_credential_report(context):
     # Cache result for future requests
     __cache_credential_report[context.current_profile] = creds_csv
     return creds_csv
+
+def get_attached_iam_policy_documents(context):
+    ''' Get only the attached IAM policies and the associated documents, and cache results '''
+    attached_iam_policy_documents = {}
+
+    if context.current_profile in __cache_attached_iam_policy_documents:
+        return __cache_attached_iam_policy_documents[context.current_profile]
+
+    iam = client(context)
+    try:
+        attached_iam_policies = iam.list_policies(OnlyAttached=True)['Policies']
+        for pol in attached_iam_policies:
+            arn = pol['Arn']
+            policy_doc = (iam.get_policy_version(PolicyArn=pol['Arn'], VersionId=pol['DefaultVersionId']))
+            # store both the policy and the associated document in a map referenced by an Arn
+            attached_iam_policy_documents[arn] = (pol, policy_doc)
+
+        # Save result in cache for future requests
+        __cache_attached_iam_policy_documents[context.current_profile] = attached_iam_policy_documents
+
+        return attached_iam_policy_documents
+
+    except Exception as e:
+        print("Get attached policies failed: " + e)
+
+
+


### PR DESCRIPTION
The check iterates through *attached* policy documents and alerts if any "NotAction" statements live next to an "Allow" effect.